### PR TITLE
Convert calculator to scientific calculator

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Calculator</title>
+  <title>Scientific Calculator</title>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
 
@@ -22,6 +22,8 @@
       --btn-op-hover:   #ff6b81;
       --btn-util-bg:    #533483;
       --btn-util-hover: #7044a3;
+      --btn-sci-bg:     #0e4d6e;
+      --btn-sci-hover:  #1a6b8e;
       --btn-eq-bg:      #0f9b58;
       --btn-eq-hover:   #12b866;
     }
@@ -41,6 +43,8 @@
       --btn-op-hover:   #ff6b81;
       --btn-util-bg:    #533483;
       --btn-util-hover: #7044a3;
+      --btn-sci-bg:     #0e4d6e;
+      --btn-sci-hover:  #1a6b8e;
       --btn-eq-bg:      #0f9b58;
       --btn-eq-hover:   #12b866;
     }
@@ -60,6 +64,8 @@
       --btn-op-hover:   #ff6b81;
       --btn-util-bg:    #7c4dab;
       --btn-util-hover: #8f5dc0;
+      --btn-sci-bg:     #2471a3;
+      --btn-sci-hover:  #2e86c1;
       --btn-eq-bg:      #0f9b58;
       --btn-eq-hover:   #12b866;
     }
@@ -79,6 +85,8 @@
       --btn-op-hover:   #48cae4;
       --btn-util-bg:    #0077b6;
       --btn-util-hover: #0096c7;
+      --btn-sci-bg:     #005f73;
+      --btn-sci-hover:  #0a7d8e;
       --btn-eq-bg:      #06d6a0;
       --btn-eq-hover:   #0ff0b3;
     }
@@ -98,6 +106,8 @@
       --btn-op-hover:   #ff8c5a;
       --btn-util-bg:    #9b59b6;
       --btn-util-hover: #ab69c6;
+      --btn-sci-bg:     #6c3483;
+      --btn-sci-hover:  #7d3c98;
       --btn-eq-bg:      #e67e22;
       --btn-eq-hover:   #f39c12;
     }
@@ -124,13 +134,13 @@
       display: flex;
       flex-direction: column;
       gap: 16px;
-      width: 320px;
+      width: 360px;
     }
 
     .calculator {
       background: var(--calc-bg);
       border-radius: 16px;
-      padding: 24px;
+      padding: 20px;
       box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4);
     }
 
@@ -139,7 +149,7 @@
       display: flex;
       align-items: center;
       gap: 10px;
-      margin-bottom: 16px;
+      margin-bottom: 12px;
     }
 
     .theme-label {
@@ -185,7 +195,7 @@
       display: flex;
       align-items: center;
       gap: 10px;
-      margin-bottom: 16px;
+      margin-bottom: 12px;
     }
 
     .font-size-label {
@@ -232,19 +242,28 @@
     .display {
       background: var(--display-bg);
       border-radius: 12px;
-      padding: 20px;
-      margin-bottom: 20px;
+      padding: 16px 20px 20px;
+      margin-bottom: 16px;
       text-align: right;
-      min-height: 80px;
+      min-height: 88px;
       display: flex;
       flex-direction: column;
       justify-content: flex-end;
     }
 
+    .display .angle-mode-indicator {
+      font-size: 10px;
+      color: var(--btn-op-bg);
+      text-align: left;
+      font-weight: 700;
+      letter-spacing: 0.12em;
+      margin-bottom: 2px;
+    }
+
     .display .expression {
-      font-size: 14px;
+      font-size: 13px;
       color: var(--text-muted);
-      min-height: 20px;
+      min-height: 18px;
       word-break: break-all;
     }
 
@@ -259,11 +278,11 @@
     .buttons {
       display: grid;
       grid-template-columns: repeat(4, 1fr);
-      gap: 10px;
+      gap: 8px;
     }
 
     button {
-      padding: 18px;
+      padding: 15px 8px;
       font-size: var(--btn-font-size);
       border: none;
       border-radius: 10px;
@@ -310,6 +329,38 @@
 
     .btn-utility:hover {
       background: var(--btn-util-hover);
+    }
+
+    /* Scientific function buttons */
+    .btn-scientific {
+      background: var(--btn-sci-bg);
+      color: #ffffff;
+      font-size: calc(var(--btn-font-size) * 0.82);
+    }
+
+    .btn-scientific:hover {
+      background: var(--btn-sci-hover);
+    }
+
+    /* Angle mode toggle — active state highlights in operator colour */
+    .btn-angle-mode {
+      background: var(--btn-sci-bg);
+      color: #ffffff;
+      font-size: calc(var(--btn-font-size) * 0.78);
+      font-weight: 600;
+      letter-spacing: 0.05em;
+    }
+
+    .btn-angle-mode:hover {
+      background: var(--btn-sci-hover);
+    }
+
+    .btn-angle-mode.rad-active {
+      background: var(--btn-op-bg);
+    }
+
+    .btn-angle-mode.rad-active:hover {
+      background: var(--btn-op-hover);
     }
 
     .btn-equals {
@@ -435,12 +486,33 @@
       </div>
 
       <div class="display" data-testid="display">
+        <div class="angle-mode-indicator" data-testid="angle-mode-indicator" id="angle-mode-indicator">DEG</div>
         <div class="expression" data-testid="expression"></div>
         <div class="value" data-testid="value">0</div>
       </div>
+
       <div class="buttons">
-        <button class="btn-clear" data-testid="btn-clear" onclick="clearAll()">C</button>
-        <button class="btn-utility" data-testid="btn-sign" onclick="toggleSign()">±</button>
+        <!-- Scientific row 1: angle mode toggle + trig functions -->
+        <button class="btn-angle-mode" data-testid="btn-angle-mode" id="angle-mode-btn" onclick="toggleAngleMode()" title="Toggle degrees / radians">DEG</button>
+        <button class="btn-scientific" data-testid="btn-sin" onclick="applyUnary('sin')">sin</button>
+        <button class="btn-scientific" data-testid="btn-cos" onclick="applyUnary('cos')">cos</button>
+        <button class="btn-scientific" data-testid="btn-tan" onclick="applyUnary('tan')">tan</button>
+
+        <!-- Scientific row 2: log / root / power -->
+        <button class="btn-scientific" data-testid="btn-log" onclick="applyUnary('log')">log</button>
+        <button class="btn-scientific" data-testid="btn-ln"  onclick="applyUnary('ln')">ln</button>
+        <button class="btn-scientific" data-testid="btn-sqrt"   onclick="applyUnary('√')">√</button>
+        <button class="btn-scientific" data-testid="btn-square" onclick="applyUnary('x²')">x²</button>
+
+        <!-- Scientific row 3: constants / extra ops -->
+        <button class="btn-scientific" data-testid="btn-power"     onclick="setOp('^')">xʸ</button>
+        <button class="btn-scientific" data-testid="btn-pi"        onclick="insertConstant('π')">π</button>
+        <button class="btn-scientific" data-testid="btn-euler"     onclick="insertConstant('e')">e</button>
+        <button class="btn-scientific" data-testid="btn-factorial" onclick="applyUnary('!')">n!</button>
+
+        <!-- Standard utility row -->
+        <button class="btn-clear"   data-testid="btn-clear"   onclick="clearAll()">C</button>
+        <button class="btn-utility" data-testid="btn-sign"    onclick="toggleSign()">±</button>
         <button class="btn-utility" data-testid="btn-percent" onclick="percent()">%</button>
         <button class="btn-operator" data-testid="btn-divide" onclick="setOp('÷')">÷</button>
 
@@ -460,7 +532,7 @@
         <button class="btn-operator" data-testid="btn-add" onclick="setOp('+')">+</button>
 
         <button class="btn-number btn-zero" data-testid="btn-0" onclick="digit('0')">0</button>
-        <button class="btn-number" data-testid="btn-decimal" onclick="decimal()">.</button>
+        <button class="btn-number" data-testid="btn-decimal"  onclick="decimal()">.</button>
         <button class="btn-utility" data-testid="btn-backspace" onclick="backspace()">⌫</button>
         <button class="btn-equals" data-testid="btn-equals" onclick="calculate()">=</button>
       </div>
@@ -484,11 +556,9 @@
 
     function setTheme(name) {
       if (!THEMES.includes(name)) name = 'dark';
-      // Remove all theme classes, then apply the chosen one (all themes use an explicit class)
       document.body.classList.remove(...THEMES.map(t => 'theme-' + t));
       document.body.classList.add('theme-' + name);
       localStorage.setItem(THEME_KEY, name);
-      // Update active indicator, ARIA checked state, and roving tabindex on dot buttons
       document.querySelectorAll('.theme-dot').forEach(function(btn) {
         const isActive = btn.dataset.theme === name;
         btn.classList.toggle('active', isActive);
@@ -497,12 +567,10 @@
       });
     }
 
-    // Attach click handlers to theme dot buttons
     document.querySelectorAll('.theme-dot').forEach(function(btn) {
       btn.addEventListener('click', function() { setTheme(btn.dataset.theme); });
     });
 
-    // Arrow-key navigation within the radiogroup (roving tabindex pattern)
     document.querySelector('.theme-dots').addEventListener('keydown', function(e) {
       if (e.key !== 'ArrowRight' && e.key !== 'ArrowLeft' &&
           e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
@@ -517,7 +585,6 @@
       dots[newIndex].focus();
     });
 
-    // Restore saved theme, respecting system color scheme preference for first-time visitors
     const savedTheme = localStorage.getItem(THEME_KEY);
     const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
     setTheme(savedTheme || (systemPrefersDark ? 'dark' : 'light'));
@@ -539,12 +606,10 @@
       });
     }
 
-    // Attach click handlers to font size buttons
     document.querySelectorAll('.font-size-btn').forEach(function(btn) {
       btn.addEventListener('click', function() { setFontSize(btn.dataset.size); });
     });
 
-    // Arrow-key navigation within the font size radiogroup (roving tabindex pattern)
     document.querySelector('.font-size-options').addEventListener('keydown', function(e) {
       if (e.key !== 'ArrowRight' && e.key !== 'ArrowLeft' &&
           e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
@@ -559,7 +624,6 @@
       btns[newIndex].focus();
     });
 
-    // Restore saved font size on page load (default: medium)
     var savedFontSize = localStorage.getItem(FONT_SIZE_KEY);
     setFontSize(savedFontSize || 'medium');
 
@@ -569,15 +633,95 @@
     let operator = '';
     let resetNext = false;
     let calcHistory = [];
+    let angleMode = 'deg'; // 'deg' | 'rad'
 
-    const display = document.querySelector('[data-testid="value"]');
+    const display    = document.querySelector('[data-testid="value"]');
     const expression = document.querySelector('[data-testid="expression"]');
     const historyList = document.querySelector('[data-testid="history-list"]');
+    const angleModeBtn = document.getElementById('angle-mode-btn');
+    const angleModeIndicator = document.getElementById('angle-mode-indicator');
 
     function updateDisplay() {
       display.textContent = current;
     }
 
+    // ── Angle Mode ────────────────────────────────────────────
+    function toggleAngleMode() {
+      angleMode = angleMode === 'deg' ? 'rad' : 'deg';
+      const label = angleMode.toUpperCase();
+      angleModeBtn.textContent = label;
+      angleModeIndicator.textContent = label;
+      angleModeBtn.classList.toggle('rad-active', angleMode === 'rad');
+    }
+
+    function toRadians(x) {
+      return angleMode === 'deg' ? x * Math.PI / 180 : x;
+    }
+
+    // ── Scientific unary operations ───────────────────────────
+    function applyUnary(name) {
+      if (current === 'Error') return;
+      const val = parseFloat(current);
+      let result;
+
+      switch (name) {
+        case 'sin': result = Math.sin(toRadians(val)); break;
+        case 'cos': result = Math.cos(toRadians(val)); break;
+        case 'tan': {
+          result = Math.tan(toRadians(val));
+          if (!isFinite(result)) { current = 'Error'; updateDisplay(); return; }
+          break;
+        }
+        case 'log': {
+          if (val <= 0) { current = 'Error'; updateDisplay(); return; }
+          result = Math.log10(val);
+          break;
+        }
+        case 'ln': {
+          if (val <= 0) { current = 'Error'; updateDisplay(); return; }
+          result = Math.log(val);
+          break;
+        }
+        case '√': {
+          if (val < 0) { current = 'Error'; updateDisplay(); return; }
+          result = Math.sqrt(val);
+          break;
+        }
+        case 'x²': result = val * val; break;
+        case '!': {
+          if (val < 0 || val !== Math.floor(val) || val > 170) {
+            current = 'Error'; updateDisplay(); return;
+          }
+          result = jsFactorial(val);
+          break;
+        }
+        default: return;
+      }
+
+      const resultStr = String(parseFloat(result.toFixed(10)));
+      const exprText = `${name}(${current}) =`;
+      expression.textContent = exprText;
+      addToHistory(exprText, resultStr);
+      current = resultStr;
+      resetNext = true;
+      updateDisplay();
+    }
+
+    function jsFactorial(n) {
+      let r = 1;
+      for (let i = 2; i <= n; i++) r *= i;
+      return r;
+    }
+
+    // ── Constants ─────────────────────────────────────────────
+    function insertConstant(name) {
+      if (name === 'π') current = String(Math.PI);
+      else if (name === 'e') current = String(Math.E);
+      resetNext = true;
+      updateDisplay();
+    }
+
+    // ── Basic input ───────────────────────────────────────────
     function digit(d) {
       if (resetNext) {
         current = d;
@@ -621,6 +765,7 @@
         case '−': result = a - b; break;
         case '×': result = a * b; break;
         case '÷': result = b !== 0 ? a / b : 'Error'; break;
+        case '^': result = Math.pow(a, b); break;
         default: return;
       }
 
@@ -660,6 +805,7 @@
       }
     }
 
+    // ── History ───────────────────────────────────────────────
     function addToHistory(expr, result) {
       calcHistory.unshift({ expression: expr, result });
       if (calcHistory.length > 5) calcHistory.pop();
@@ -727,7 +873,7 @@
     function backspace() {
       if (!resetNext && current.length > 1) {
         const sliced = current.slice(0, -1);
-        current = sliced === '-' ? '0' : sliced;  // don't leave a bare '-'
+        current = sliced === '-' ? '0' : sliced;
       } else {
         current = '0';
         resetNext = false;
@@ -735,7 +881,7 @@
       updateDisplay();
     }
 
-    // Keyboard support
+    // ── Keyboard support ──────────────────────────────────────
     document.addEventListener('keydown', function(e) {
       if (e.key >= '0' && e.key <= '9') {
         digit(e.key);
@@ -750,6 +896,8 @@
       } else if (e.key === '/') {
         e.preventDefault();
         setOp('÷');
+      } else if (e.key === '^') {
+        setOp('^');
       } else if (e.key === 'Enter' || e.key === '=') {
         calculate();
       } else if (e.key === 'Escape') {

--- a/main.py
+++ b/main.py
@@ -1,16 +1,135 @@
-"""Simple calculator module."""
+"""Scientific calculator module."""
+import math
 
 
-def add(a: int, b: int) -> int:
+def add(a: float, b: float) -> float:
     """Add two numbers."""
     return a + b
 
 
-def subtract(a: int, b: int) -> int:
+def subtract(a: float, b: float) -> float:
     """Subtract b from a."""
     return a - b
+
+
+def multiply(a: float, b: float) -> float:
+    """Multiply two numbers."""
+    return a * b
+
+
+def divide(a: float, b: float) -> float:
+    """Divide a by b.
+
+    Raises:
+        ZeroDivisionError: If b is zero.
+    """
+    if b == 0:
+        raise ZeroDivisionError("Cannot divide by zero")
+    return a / b
+
+
+def power(base: float, exp: float) -> float:
+    """Raise base to the power of exp."""
+    return math.pow(base, exp)
+
+
+def sqrt(x: float) -> float:
+    """Square root of x.
+
+    Raises:
+        ValueError: If x is negative.
+    """
+    if x < 0:
+        raise ValueError("Cannot take square root of a negative number")
+    return math.sqrt(x)
+
+
+def sin_deg(x: float) -> float:
+    """Sine of x given in degrees."""
+    return math.sin(math.radians(x))
+
+
+def cos_deg(x: float) -> float:
+    """Cosine of x given in degrees."""
+    return math.cos(math.radians(x))
+
+
+def tan_deg(x: float) -> float:
+    """Tangent of x given in degrees.
+
+    Raises:
+        ValueError: If tangent is undefined at the given angle (e.g. 90°, 270°).
+    """
+    result = math.tan(math.radians(x))
+    if not math.isfinite(result):
+        raise ValueError("Tangent is undefined at this angle")
+    return result
+
+
+def sin_rad(x: float) -> float:
+    """Sine of x given in radians."""
+    return math.sin(x)
+
+
+def cos_rad(x: float) -> float:
+    """Cosine of x given in radians."""
+    return math.cos(x)
+
+
+def tan_rad(x: float) -> float:
+    """Tangent of x given in radians.
+
+    Raises:
+        ValueError: If tangent is undefined at the given angle.
+    """
+    result = math.tan(x)
+    if not math.isfinite(result):
+        raise ValueError("Tangent is undefined at this angle")
+    return result
+
+
+def log10(x: float) -> float:
+    """Base-10 logarithm of x.
+
+    Raises:
+        ValueError: If x is not positive.
+    """
+    if x <= 0:
+        raise ValueError("Logarithm is undefined for non-positive numbers")
+    return math.log10(x)
+
+
+def ln(x: float) -> float:
+    """Natural logarithm of x.
+
+    Raises:
+        ValueError: If x is not positive.
+    """
+    if x <= 0:
+        raise ValueError("Logarithm is undefined for non-positive numbers")
+    return math.log(x)
+
+
+def factorial(n: float) -> int:
+    """Factorial of non-negative integer n.
+
+    Raises:
+        ValueError: If n is negative or not an integer.
+    """
+    if n != int(n) or n < 0:
+        raise ValueError("Factorial is undefined for negative or non-integer values")
+    return math.factorial(int(n))
 
 
 if __name__ == "__main__":
     print(f"2 + 3 = {add(2, 3)}")
     print(f"5 - 2 = {subtract(5, 2)}")
+    print(f"3 × 4 = {multiply(3, 4)}")
+    print(f"10 ÷ 2 = {divide(10, 2)}")
+    print(f"2 ^ 8 = {power(2, 8)}")
+    print(f"√16 = {sqrt(16)}")
+    print(f"sin(30°) = {sin_deg(30)}")
+    print(f"cos(60°) = {cos_deg(60)}")
+    print(f"log(100) = {log10(100)}")
+    print(f"ln(e) = {ln(math.e)}")
+    print(f"5! = {factorial(5)}")

--- a/test_main.py
+++ b/test_main.py
@@ -1,12 +1,148 @@
-"""Tests for calculator module."""
-from main import add, subtract
+"""Tests for scientific calculator module."""
+import math
+import pytest
+from main import (
+    add, subtract, multiply, divide,
+    power, sqrt,
+    sin_deg, cos_deg, tan_deg,
+    sin_rad, cos_rad, tan_rad,
+    log10, ln, factorial,
+)
 
+
+# ── Basic arithmetic ──────────────────────────────────────────────────────────
 
 def test_add():
     assert add(2, 3) == 5
     assert add(-1, 1) == 0
+    assert add(0.1, 0.2) == pytest.approx(0.3)
 
 
 def test_subtract():
     assert subtract(5, 2) == 3
     assert subtract(0, 0) == 0
+    assert subtract(-3, -1) == -2
+
+
+def test_multiply():
+    assert multiply(3, 4) == 12
+    assert multiply(-2, 5) == -10
+    assert multiply(0, 999) == 0
+    assert multiply(0.5, 4) == pytest.approx(2.0)
+
+
+def test_divide():
+    assert divide(10, 2) == 5
+    assert divide(7, 2) == pytest.approx(3.5)
+    assert divide(-9, 3) == -3
+
+
+def test_divide_by_zero():
+    with pytest.raises(ZeroDivisionError):
+        divide(5, 0)
+
+
+# ── Power & roots ─────────────────────────────────────────────────────────────
+
+def test_power():
+    assert power(2, 10) == pytest.approx(1024.0)
+    assert power(3, 0) == pytest.approx(1.0)
+    assert power(4, 0.5) == pytest.approx(2.0)
+    assert power(2, -1) == pytest.approx(0.5)
+
+
+def test_sqrt():
+    assert sqrt(16) == pytest.approx(4.0)
+    assert sqrt(2) == pytest.approx(math.sqrt(2))
+    assert sqrt(0) == pytest.approx(0.0)
+
+
+def test_sqrt_negative():
+    with pytest.raises(ValueError):
+        sqrt(-1)
+
+
+# ── Trigonometry (degrees) ────────────────────────────────────────────────────
+
+def test_sin_deg():
+    assert sin_deg(0) == pytest.approx(0.0)
+    assert sin_deg(30) == pytest.approx(0.5)
+    assert sin_deg(90) == pytest.approx(1.0)
+    assert sin_deg(180) == pytest.approx(0.0, abs=1e-9)
+    assert sin_deg(-90) == pytest.approx(-1.0)
+
+
+def test_cos_deg():
+    assert cos_deg(0) == pytest.approx(1.0)
+    assert cos_deg(60) == pytest.approx(0.5)
+    assert cos_deg(90) == pytest.approx(0.0, abs=1e-9)
+    assert cos_deg(180) == pytest.approx(-1.0)
+
+
+def test_tan_deg():
+    assert tan_deg(0) == pytest.approx(0.0)
+    assert tan_deg(45) == pytest.approx(1.0)
+    assert tan_deg(-45) == pytest.approx(-1.0)
+
+
+# ── Trigonometry (radians) ────────────────────────────────────────────────────
+
+def test_sin_rad():
+    assert sin_rad(0) == pytest.approx(0.0)
+    assert sin_rad(math.pi / 6) == pytest.approx(0.5)
+    assert sin_rad(math.pi / 2) == pytest.approx(1.0)
+
+
+def test_cos_rad():
+    assert cos_rad(0) == pytest.approx(1.0)
+    assert cos_rad(math.pi / 3) == pytest.approx(0.5)
+    assert cos_rad(math.pi) == pytest.approx(-1.0)
+
+
+def test_tan_rad():
+    assert tan_rad(0) == pytest.approx(0.0)
+    assert tan_rad(math.pi / 4) == pytest.approx(1.0)
+
+
+# ── Logarithms ────────────────────────────────────────────────────────────────
+
+def test_log10():
+    assert log10(100) == pytest.approx(2.0)
+    assert log10(1) == pytest.approx(0.0)
+    assert log10(1000) == pytest.approx(3.0)
+
+
+def test_log10_invalid():
+    with pytest.raises(ValueError):
+        log10(0)
+    with pytest.raises(ValueError):
+        log10(-5)
+
+
+def test_ln():
+    assert ln(math.e) == pytest.approx(1.0)
+    assert ln(1) == pytest.approx(0.0)
+    assert ln(math.e ** 3) == pytest.approx(3.0)
+
+
+def test_ln_invalid():
+    with pytest.raises(ValueError):
+        ln(0)
+    with pytest.raises(ValueError):
+        ln(-1)
+
+
+# ── Factorial ─────────────────────────────────────────────────────────────────
+
+def test_factorial():
+    assert factorial(0) == 1
+    assert factorial(1) == 1
+    assert factorial(5) == 120
+    assert factorial(10) == 3628800
+
+
+def test_factorial_invalid():
+    with pytest.raises(ValueError):
+        factorial(-1)
+    with pytest.raises(ValueError):
+        factorial(2.5)

--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -846,4 +846,232 @@ test.describe("Calculator UI", () => {
       await expect(page.getByTestId("value")).toHaveText("7");
     });
   });
+
+  // ── Scientific Calculator tests ────────────────────────────────────────────
+  test.describe("Scientific Calculator", () => {
+    // --- Button visibility ---
+    test("scientific buttons are visible", async ({ page }) => {
+      await expect(page.getByTestId("btn-sin")).toBeVisible();
+      await expect(page.getByTestId("btn-cos")).toBeVisible();
+      await expect(page.getByTestId("btn-tan")).toBeVisible();
+      await expect(page.getByTestId("btn-log")).toBeVisible();
+      await expect(page.getByTestId("btn-ln")).toBeVisible();
+      await expect(page.getByTestId("btn-sqrt")).toBeVisible();
+      await expect(page.getByTestId("btn-square")).toBeVisible();
+      await expect(page.getByTestId("btn-power")).toBeVisible();
+      await expect(page.getByTestId("btn-pi")).toBeVisible();
+      await expect(page.getByTestId("btn-euler")).toBeVisible();
+      await expect(page.getByTestId("btn-factorial")).toBeVisible();
+      await expect(page.getByTestId("btn-angle-mode")).toBeVisible();
+    });
+
+    test("angle mode indicator is visible in display", async ({ page }) => {
+      await expect(page.getByTestId("angle-mode-indicator")).toBeVisible();
+    });
+
+    test("angle mode defaults to DEG", async ({ page }) => {
+      await expect(page.getByTestId("btn-angle-mode")).toHaveText("DEG");
+      await expect(page.getByTestId("angle-mode-indicator")).toHaveText("DEG");
+    });
+
+    // --- Angle mode toggle ---
+    test("clicking angle mode toggles to RAD", async ({ page }) => {
+      await page.getByTestId("btn-angle-mode").click();
+      await expect(page.getByTestId("btn-angle-mode")).toHaveText("RAD");
+      await expect(page.getByTestId("angle-mode-indicator")).toHaveText("RAD");
+    });
+
+    test("clicking angle mode twice returns to DEG", async ({ page }) => {
+      await page.getByTestId("btn-angle-mode").click();
+      await page.getByTestId("btn-angle-mode").click();
+      await expect(page.getByTestId("btn-angle-mode")).toHaveText("DEG");
+    });
+
+    // --- Trig functions (degrees mode) ---
+    test("sin(30) in degrees equals 0.5", async ({ page }) => {
+      await page.getByTestId("btn-3").click();
+      await page.getByTestId("btn-0").click();
+      await page.getByTestId("btn-sin").click();
+      await expect(page.getByTestId("value")).toHaveText("0.5");
+    });
+
+    test("cos(60) in degrees equals 0.5", async ({ page }) => {
+      await page.getByTestId("btn-6").click();
+      await page.getByTestId("btn-0").click();
+      await page.getByTestId("btn-cos").click();
+      await expect(page.getByTestId("value")).toHaveText("0.5");
+    });
+
+    test("tan(45) in degrees equals 1", async ({ page }) => {
+      await page.getByTestId("btn-4").click();
+      await page.getByTestId("btn-5").click();
+      await page.getByTestId("btn-tan").click();
+      await expect(page.getByTestId("value")).toHaveText("1");
+    });
+
+    test("sin(0) in degrees equals 0", async ({ page }) => {
+      await page.getByTestId("btn-sin").click();
+      await expect(page.getByTestId("value")).toHaveText("0");
+    });
+
+    // --- Trig functions (radians mode) ---
+    test("sin in radians mode: sin(π/6) ≈ 0.5", async ({ page }) => {
+      // Switch to RAD
+      await page.getByTestId("btn-angle-mode").click();
+      // Enter π/6 ≈ 0.5236
+      await page.getByTestId("btn-pi").click();
+      await page.getByTestId("btn-divide").click();
+      await page.getByTestId("btn-6").click();
+      await page.getByTestId("btn-equals").click();
+      // Now apply sin
+      await page.getByTestId("btn-sin").click();
+      const text = await page.getByTestId("value").textContent();
+      expect(parseFloat(text)).toBeCloseTo(0.5, 5);
+    });
+
+    // --- log / ln ---
+    test("log(100) equals 2", async ({ page }) => {
+      await page.getByTestId("btn-1").click();
+      await page.getByTestId("btn-0").click();
+      await page.getByTestId("btn-0").click();
+      await page.getByTestId("btn-log").click();
+      await expect(page.getByTestId("value")).toHaveText("2");
+    });
+
+    test("log(1) equals 0", async ({ page }) => {
+      await page.getByTestId("btn-1").click();
+      await page.getByTestId("btn-log").click();
+      await expect(page.getByTestId("value")).toHaveText("0");
+    });
+
+    test("log of 0 shows Error", async ({ page }) => {
+      // default display is 0; pressing log should show Error
+      await page.getByTestId("btn-log").click();
+      await expect(page.getByTestId("value")).toHaveText("Error");
+    });
+
+    test("ln(1) equals 0", async ({ page }) => {
+      await page.getByTestId("btn-1").click();
+      await page.getByTestId("btn-ln").click();
+      await expect(page.getByTestId("value")).toHaveText("0");
+    });
+
+    test("ln of 0 shows Error", async ({ page }) => {
+      await page.getByTestId("btn-ln").click();
+      await expect(page.getByTestId("value")).toHaveText("Error");
+    });
+
+    // --- sqrt ---
+    test("sqrt(9) equals 3", async ({ page }) => {
+      await page.getByTestId("btn-9").click();
+      await page.getByTestId("btn-sqrt").click();
+      await expect(page.getByTestId("value")).toHaveText("3");
+    });
+
+    test("sqrt(4) equals 2", async ({ page }) => {
+      await page.getByTestId("btn-4").click();
+      await page.getByTestId("btn-sqrt").click();
+      await expect(page.getByTestId("value")).toHaveText("2");
+    });
+
+    test("sqrt of negative number shows Error", async ({ page }) => {
+      await page.getByTestId("btn-9").click();
+      await page.getByTestId("btn-sign").click(); // -9
+      await page.getByTestId("btn-sqrt").click();
+      await expect(page.getByTestId("value")).toHaveText("Error");
+    });
+
+    // --- square (x²) ---
+    test("x² of 5 equals 25", async ({ page }) => {
+      await page.getByTestId("btn-5").click();
+      await page.getByTestId("btn-square").click();
+      await expect(page.getByTestId("value")).toHaveText("25");
+    });
+
+    test("x² of 3 equals 9", async ({ page }) => {
+      await page.getByTestId("btn-3").click();
+      await page.getByTestId("btn-square").click();
+      await expect(page.getByTestId("value")).toHaveText("9");
+    });
+
+    // --- power (xʸ) ---
+    test("2 xʸ 8 equals 256", async ({ page }) => {
+      await page.getByTestId("btn-2").click();
+      await page.getByTestId("btn-power").click();
+      await page.getByTestId("btn-8").click();
+      await page.getByTestId("btn-equals").click();
+      await expect(page.getByTestId("value")).toHaveText("256");
+    });
+
+    test("3 xʸ 3 equals 27", async ({ page }) => {
+      await page.getByTestId("btn-3").click();
+      await page.getByTestId("btn-power").click();
+      await page.getByTestId("btn-3").click();
+      await page.getByTestId("btn-equals").click();
+      await expect(page.getByTestId("value")).toHaveText("27");
+    });
+
+    // --- Constants ---
+    test("pressing π inserts pi value", async ({ page }) => {
+      await page.getByTestId("btn-pi").click();
+      const text = await page.getByTestId("value").textContent();
+      expect(parseFloat(text)).toBeCloseTo(Math.PI, 5);
+    });
+
+    test("pressing e inserts Euler's number", async ({ page }) => {
+      await page.getByTestId("btn-euler").click();
+      const text = await page.getByTestId("value").textContent();
+      expect(parseFloat(text)).toBeCloseTo(Math.E, 5);
+    });
+
+    test("π can be used in arithmetic: π × 2", async ({ page }) => {
+      await page.getByTestId("btn-pi").click();
+      await page.getByTestId("btn-multiply").click();
+      await page.getByTestId("btn-2").click();
+      await page.getByTestId("btn-equals").click();
+      const text = await page.getByTestId("value").textContent();
+      expect(parseFloat(text)).toBeCloseTo(2 * Math.PI, 5);
+    });
+
+    // --- factorial (n!) ---
+    test("5! equals 120", async ({ page }) => {
+      await page.getByTestId("btn-5").click();
+      await page.getByTestId("btn-factorial").click();
+      await expect(page.getByTestId("value")).toHaveText("120");
+    });
+
+    test("0! equals 1", async ({ page }) => {
+      await page.getByTestId("btn-factorial").click();
+      await expect(page.getByTestId("value")).toHaveText("1");
+    });
+
+    test("factorial of negative number shows Error", async ({ page }) => {
+      await page.getByTestId("btn-5").click();
+      await page.getByTestId("btn-sign").click(); // -5
+      await page.getByTestId("btn-factorial").click();
+      await expect(page.getByTestId("value")).toHaveText("Error");
+    });
+
+    // --- History integration ---
+    test("scientific unary result is added to history", async ({ page }) => {
+      await page.getByTestId("btn-9").click();
+      await page.getByTestId("btn-sqrt").click();
+      await expect(page.getByTestId("history-item-0")).toBeVisible();
+      await expect(page.getByTestId("history-result-0")).toHaveText("3");
+    });
+
+    test("expression in history shows function notation for unary ops", async ({ page }) => {
+      await page.getByTestId("btn-9").click();
+      await page.getByTestId("btn-sqrt").click();
+      await expect(page.getByTestId("history-expression-0")).toContainText("√");
+    });
+
+    test("power result is added to history", async ({ page }) => {
+      await page.getByTestId("btn-2").click();
+      await page.getByTestId("btn-power").click();
+      await page.getByTestId("btn-4").click();
+      await page.getByTestId("btn-equals").click();
+      await expect(page.getByTestId("history-result-0")).toHaveText("16");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- **Backend (`main.py`)**: Added `multiply`, `divide`, `power`, `sqrt`, `sin_deg`/`cos_deg`/`tan_deg`, `sin_rad`/`cos_rad`/`tan_rad`, `log10`, `ln`, and `factorial` functions with type hints and docstrings.
- **Frontend (`index.html`)**: Added three rows of scientific buttons (sin/cos/tan, log/ln/√/x², xʸ/π/e/n!) with a DEG/RAD angle-mode toggle and indicator in the display; widened the calculator layout; all themes updated with a new `--btn-sci-bg` colour variable.
- **Tests (`test_main.py`)**: Expanded from 2 to 20 unit tests covering all new scientific functions, edge-cases, and error conditions.
- **UI tests (`tests/ui.spec.js`)**: Added a `Scientific Calculator` describe block with 30 Playwright tests covering button visibility, angle-mode toggle, trig in DEG/RAD, log/ln, sqrt, x², xʸ, constants (π, e), factorial, and history integration.

## Test plan

- [ ] `python -m pytest test_main.py -v` — all 20 tests pass
- [ ] `npx playwright test` — existing tests unaffected; new scientific tests pass
- [ ] Manual smoke-test: open `http://localhost:3000`, verify scientific buttons are displayed and produce correct results

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)