### PR TITLE
Add expression-based input mode with parser and parentheses support

### DIFF
--- a/index.html
+++ b/index.html
@@ -377,6 +377,66 @@
       grid-column: span 2;
     }
 
+    /* ── Expression Mode Toggle ───────────────────────────── */
+    .mode-switcher {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin-bottom: 12px;
+    }
+
+    .mode-label {
+      font-size: 11px;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-weight: 500;
+    }
+
+    .mode-toggle-btn {
+      padding: 4px 12px;
+      font-size: 12px;
+      background: var(--btn-sci-bg);
+      color: #ffffff;
+      border: none;
+      border-radius: 6px;
+      cursor: pointer;
+      transition: background 0.15s;
+      font-family: inherit;
+      font-weight: 500;
+    }
+
+    .mode-toggle-btn:hover {
+      background: var(--btn-sci-hover);
+    }
+
+    .mode-toggle-btn.active {
+      background: var(--btn-op-bg);
+    }
+
+    .mode-toggle-btn.active:hover {
+      background: var(--btn-op-hover);
+    }
+
+    /* Expression mode input */
+    .expr-input {
+      width: 100%;
+      background: transparent;
+      border: none;
+      color: var(--text-main);
+      font-size: var(--display-font-size);
+      font-weight: 300;
+      font-family: inherit;
+      text-align: right;
+      outline: none;
+      word-break: break-all;
+    }
+
+    .expr-input::placeholder {
+      color: var(--text-muted);
+      opacity: 0.6;
+    }
+
     /* ── History Panel ─────────────────────────────────────── */
     .history-panel {
       background: var(--calc-bg);
@@ -485,10 +545,17 @@
         </div>
       </div>
 
+      <!-- Mode Switcher -->
+      <div class="mode-switcher" data-testid="mode-switcher">
+        <span class="mode-label">Mode</span>
+        <button class="mode-toggle-btn" data-testid="btn-mode-toggle" onclick="toggleMode()">Expression</button>
+      </div>
+
       <div class="display" data-testid="display">
         <div class="angle-mode-indicator" data-testid="angle-mode-indicator" id="angle-mode-indicator">DEG</div>
         <div class="expression" data-testid="expression"></div>
         <div class="value" data-testid="value">0</div>
+        <input class="expr-input" data-testid="expr-input" id="expr-input" type="text" placeholder="e.g. (2+3)*sin(45)" style="display:none;" />
       </div>
 
       <div class="buttons">
@@ -534,7 +601,11 @@
         <button class="btn-number btn-zero" data-testid="btn-0" onclick="digit('0')">0</button>
         <button class="btn-number" data-testid="btn-decimal"  onclick="decimal()">.</button>
         <button class="btn-utility" data-testid="btn-backspace" onclick="backspace()">⌫</button>
-        <button class="btn-equals" data-testid="btn-equals" onclick="calculate()">=</button>
+
+        <!-- Parentheses row (visible in expression mode) -->
+        <button class="btn-scientific" data-testid="btn-open-paren" id="btn-open-paren" onclick="exprInsert('(')" style="display:none;">(</button>
+        <button class="btn-scientific" data-testid="btn-close-paren" id="btn-close-paren" onclick="exprInsert(')')" style="display:none;">)</button>
+        <button class="btn-equals" data-testid="btn-equals" onclick="handleEquals()" id="btn-equals">=</button>
       </div>
     </div>
 
@@ -626,6 +697,258 @@
 
     var savedFontSize = localStorage.getItem(FONT_SIZE_KEY);
     setFontSize(savedFontSize || 'medium');
+
+    // ── Expression Mode ──────────────────────────────────────
+    const MODE_KEY = 'calc-mode';
+    let expressionMode = false;  // false = standard, true = expression
+    const modeToggleBtn = document.querySelector('[data-testid="btn-mode-toggle"]');
+    const exprInput = document.getElementById('expr-input');
+    const btnOpenParen = document.getElementById('btn-open-paren');
+    const btnCloseParen = document.getElementById('btn-close-paren');
+    const btnEquals = document.getElementById('btn-equals');
+    const valueDisplay = document.querySelector('[data-testid="value"]');
+    const expressionDisplay = document.querySelector('[data-testid="expression"]');
+
+    function setMode(isExprMode) {
+      expressionMode = isExprMode;
+      localStorage.setItem(MODE_KEY, isExprMode ? 'expression' : 'standard');
+      modeToggleBtn.classList.toggle('active', isExprMode);
+      modeToggleBtn.textContent = isExprMode ? 'Standard' : 'Expression';
+
+      if (isExprMode) {
+        valueDisplay.style.display = 'none';
+        exprInput.style.display = 'block';
+        btnOpenParen.style.display = '';
+        btnCloseParen.style.display = '';
+        btnEquals.style.gridColumn = 'span 2';
+        exprInput.focus();
+      } else {
+        valueDisplay.style.display = '';
+        exprInput.style.display = 'none';
+        btnOpenParen.style.display = 'none';
+        btnCloseParen.style.display = 'none';
+        btnEquals.style.gridColumn = 'span 4';
+      }
+    }
+
+    function toggleMode() {
+      setMode(!expressionMode);
+    }
+
+    // Restore saved mode
+    var savedMode = localStorage.getItem(MODE_KEY);
+    setMode(savedMode === 'expression');
+
+    function exprInsert(text) {
+      if (!expressionMode) return;
+      var start = exprInput.selectionStart;
+      var end = exprInput.selectionEnd;
+      var val = exprInput.value;
+      exprInput.value = val.substring(0, start) + text + val.substring(end);
+      exprInput.selectionStart = exprInput.selectionEnd = start + text.length;
+      exprInput.focus();
+    }
+
+    function evaluateExpr() {
+      var expr = exprInput.value.trim();
+      if (!expr) return;
+      try {
+        // Use a simple fetch to the backend or evaluate locally
+        // For a static frontend, we implement a JS-based expression parser
+        var result = jsEvaluateExpression(expr);
+        var resultStr = String(parseFloat(result.toFixed(10)));
+        expressionDisplay.textContent = expr + ' =';
+        valueDisplay.textContent = resultStr;
+        valueDisplay.style.display = '';
+        exprInput.style.display = 'none';
+        addToHistory(expr + ' =', resultStr);
+        // After showing result, a click on input should show again
+        setTimeout(function() {
+          if (expressionMode) {
+            valueDisplay.style.display = 'none';
+            exprInput.style.display = 'block';
+            exprInput.value = '';
+            exprInput.focus();
+          }
+        }, 1500);
+      } catch (e) {
+        expressionDisplay.textContent = expr + ' =';
+        valueDisplay.textContent = 'Error';
+        valueDisplay.style.display = '';
+        exprInput.style.display = 'none';
+        addToHistory(expr + ' =', 'Error');
+        setTimeout(function() {
+          if (expressionMode) {
+            valueDisplay.style.display = 'none';
+            exprInput.style.display = 'block';
+            exprInput.value = '';
+            exprInput.focus();
+          }
+        }, 1500);
+      }
+    }
+
+    // Handle = button depending on mode
+    function handleEquals() {
+      if (expressionMode) {
+        evaluateExpr();
+      } else {
+        calculate();
+      }
+    }
+
+    // Listen for Enter on expr input
+    exprInput.addEventListener('keydown', function(e) {
+      if (e.key === 'Enter' || e.key === '=') {
+        e.preventDefault();
+        evaluateExpr();
+      }
+    });
+
+    // ── JS Expression Parser (mirrors Python backend) ─────────
+    function jsEvaluateExpression(expr) {
+      var tokens = jsTokenize(expr);
+      var pos = { i: 0 };
+      var result = jsParseExpr(tokens, pos);
+      if (pos.i < tokens.length) throw new Error("Unexpected token: " + tokens[pos.i][1]);
+      if (!isFinite(result)) throw new Error("Result is not finite");
+      return result;
+    }
+
+    function jsTokenize(expr) {
+      var tokens = [];
+      var i = 0;
+      while (i < expr.length) {
+        var ch = expr[i];
+        if (ch === ' ' || ch === '\t') { i++; continue; }
+        if ('()+-*/^'.indexOf(ch) >= 0) {
+          tokens.push(['OP', ch]);
+          i++;
+        } else if (ch === ',') {
+          tokens.push(['COMMA', ',']);
+          i++;
+        } else if ((ch >= '0' && ch <= '9') || ch === '.') {
+          var j = i;
+          var dotSeen = ch === '.';
+          while (j + 1 < expr.length && ((expr[j+1] >= '0' && expr[j+1] <= '9') || (expr[j+1] === '.' && !dotSeen))) {
+            j++;
+            if (expr[j] === '.') dotSeen = true;
+          }
+          tokens.push(['NUM', expr.substring(i, j + 1)]);
+          i = j + 1;
+        } else if ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch === '_') {
+          var j = i;
+          while (j + 1 < expr.length && ((expr[j+1] >= 'a' && expr[j+1] <= 'z') || (expr[j+1] >= 'A' && expr[j+1] <= 'Z') || (expr[j+1] >= '0' && expr[j+1] <= '9') || expr[j+1] === '_')) {
+            j++;
+          }
+          tokens.push(['ID', expr.substring(i, j + 1)]);
+          i = j + 1;
+        } else {
+          throw new Error("Unexpected character: '" + ch + "'");
+        }
+      }
+      return tokens;
+    }
+
+    var jsAngleMode = function() { return angleMode; };
+
+    var jsFunctions = {
+      'sin': function(x) { return Math.sin(angleMode === 'deg' ? x * Math.PI / 180 : x); },
+      'cos': function(x) { return Math.cos(angleMode === 'deg' ? x * Math.PI / 180 : x); },
+      'tan': function(x) { return Math.tan(angleMode === 'deg' ? x * Math.PI / 180 : x); },
+      'log': function(x) { if (x <= 0) throw new Error("Log domain error"); return Math.log10(x); },
+      'ln': function(x) { if (x <= 0) throw new Error("Ln domain error"); return Math.log(x); },
+      'sqrt': function(x) { if (x < 0) throw new Error("Sqrt domain error"); return Math.sqrt(x); },
+      'factorial': function(x) {
+        if (x < 0 || x !== Math.floor(x) || x > 170) throw new Error("Factorial domain error");
+        return jsFactorial(x);
+      },
+      'abs': function(x) { return Math.abs(x); },
+      'power': function(x, y) { return Math.pow(x, y); }
+    };
+
+    var jsConstants = { 'pi': Math.PI, 'e': Math.E };
+
+    function jsParseExpr(tokens, pos) {
+      var left = jsParseTerm(tokens, pos);
+      while (pos.i < tokens.length && tokens[pos.i][0] === 'OP' && (tokens[pos.i][1] === '+' || tokens[pos.i][1] === '-')) {
+        var op = tokens[pos.i][1]; pos.i++;
+        var right = jsParseTerm(tokens, pos);
+        left = op === '+' ? left + right : left - right;
+      }
+      return left;
+    }
+
+    function jsParseTerm(tokens, pos) {
+      var left = jsParseExponent(tokens, pos);
+      while (pos.i < tokens.length && tokens[pos.i][0] === 'OP' && (tokens[pos.i][1] === '*' || tokens[pos.i][1] === '/')) {
+        var op = tokens[pos.i][1]; pos.i++;
+        var right = jsParseExponent(tokens, pos);
+        if (op === '*') left = left * right;
+        else {
+          if (right === 0) throw new Error("Division by zero");
+          left = left / right;
+        }
+      }
+      return left;
+    }
+
+    function jsParseExponent(tokens, pos) {
+      var base = jsParseUnary(tokens, pos);
+      if (pos.i < tokens.length && tokens[pos.i][0] === 'OP' && tokens[pos.i][1] === '^') {
+        pos.i++;
+        var exp = jsParseExponent(tokens, pos);
+        base = Math.pow(base, exp);
+      }
+      return base;
+    }
+
+    function jsParseUnary(tokens, pos) {
+      if (pos.i < tokens.length && tokens[pos.i][0] === 'OP' && tokens[pos.i][1] === '-') {
+        pos.i++;
+        return -jsParseUnary(tokens, pos);
+      }
+      return jsParsePrimary(tokens, pos);
+    }
+
+    function jsParsePrimary(tokens, pos) {
+      if (pos.i >= tokens.length) throw new Error("Unexpected end of expression");
+      var tok = tokens[pos.i];
+
+      if (tok[0] === 'NUM') {
+        pos.i++;
+        return parseFloat(tok[1]);
+      }
+
+      if (tok[0] === 'ID') {
+        var name = tok[1].toLowerCase();
+        pos.i++;
+        if (pos.i < tokens.length && tokens[pos.i][0] === 'OP' && tokens[pos.i][1] === '(') {
+          if (!jsFunctions[name]) throw new Error("Unknown function: " + name);
+          pos.i++; // consume (
+          var args = [jsParseExpr(tokens, pos)];
+          while (pos.i < tokens.length && tokens[pos.i][0] === 'COMMA') {
+            pos.i++;
+            args.push(jsParseExpr(tokens, pos));
+          }
+          if (pos.i >= tokens.length || tokens[pos.i][1] !== ')') throw new Error("Expected )");
+          pos.i++; // consume )
+          return jsFunctions[name].apply(null, args);
+        }
+        if (jsConstants[name] !== undefined) return jsConstants[name];
+        throw new Error("Unknown identifier: " + name);
+      }
+
+      if (tok[0] === 'OP' && tok[1] === '(') {
+        pos.i++;
+        var result = jsParseExpr(tokens, pos);
+        if (pos.i >= tokens.length || tokens[pos.i][1] !== ')') throw new Error("Expected )");
+        pos.i++;
+        return result;
+      }
+
+      throw new Error("Unexpected token: " + tok[1]);
+    }
 
     // ── Calculator State ──────────────────────────────────────
     let current = '0';
@@ -723,6 +1046,7 @@
 
     // ── Basic input ───────────────────────────────────────────
     function digit(d) {
+      if (expressionMode) { exprInsert(d); return; }
       if (resetNext) {
         current = d;
         resetNext = false;
@@ -733,6 +1057,7 @@
     }
 
     function decimal() {
+      if (expressionMode) { exprInsert('.'); return; }
       if (resetNext) {
         current = '0.';
         resetNext = false;
@@ -883,6 +1208,9 @@
 
     // ── Keyboard support ──────────────────────────────────────
     document.addEventListener('keydown', function(e) {
+      // In expression mode, let the input handle its own events
+      if (expressionMode && document.activeElement === exprInput) return;
+
       if (e.key >= '0' && e.key <= '9') {
         digit(e.key);
       } else if (e.key === '.') {
@@ -899,7 +1227,7 @@
       } else if (e.key === '^') {
         setOp('^');
       } else if (e.key === 'Enter' || e.key === '=') {
-        calculate();
+        handleEquals();
       } else if (e.key === 'Escape') {
         clearAll();
       } else if (e.key === '%') {

--- a/main.py
+++ b/main.py
@@ -121,6 +121,254 @@ def factorial(n: float) -> int:
     return math.factorial(int(n))
 
 
+# ── Expression Evaluator (Recursive Descent Parser) ──────────────────────────
+
+class _Tokenizer:
+    """Tokenizes a mathematical expression string."""
+
+    def __init__(self, expr: str) -> None:
+        self.expr = expr
+        self.pos = 0
+        self.tokens: list[tuple[str, str]] = []
+        self._tokenize()
+        self.pos = 0
+
+    def _tokenize(self) -> None:
+        """Convert expression string into a list of (type, value) tokens."""
+        i = 0
+        s = self.expr
+        while i < len(s):
+            ch = s[i]
+            if ch.isspace():
+                i += 1
+                continue
+            if ch in '()+-*/^':
+                self.tokens.append(('OP', ch))
+                i += 1
+            elif ch == ',':
+                self.tokens.append(('COMMA', ','))
+                i += 1
+            elif ch.isdigit() or ch == '.':
+                j = i
+                dot_seen = ch == '.'
+                while j + 1 < len(s) and (s[j + 1].isdigit() or (s[j + 1] == '.' and not dot_seen)):
+                    j += 1
+                    if s[j] == '.':
+                        dot_seen = True
+                self.tokens.append(('NUM', s[i:j + 1]))
+                i = j + 1
+            elif ch.isalpha() or ch == '_':
+                j = i
+                while j + 1 < len(s) and (s[j + 1].isalnum() or s[j + 1] == '_'):
+                    j += 1
+                self.tokens.append(('ID', s[i:j + 1]))
+                i = j + 1
+            else:
+                raise ValueError(f"Unexpected character: '{ch}'")
+
+    def peek(self) -> tuple[str, str] | None:
+        """Look at the current token without consuming it."""
+        if self.pos < len(self.tokens):
+            return self.tokens[self.pos]
+        return None
+
+    def consume(self) -> tuple[str, str]:
+        """Consume and return the current token."""
+        tok = self.tokens[self.pos]
+        self.pos += 1
+        return tok
+
+    def expect(self, tok_type: str, tok_val: str | None = None) -> tuple[str, str]:
+        """Consume a token, raising ValueError if it doesn't match."""
+        if self.pos >= len(self.tokens):
+            raise ValueError(f"Expected {tok_val or tok_type}, got end of expression")
+        tok = self.consume()
+        if tok[0] != tok_type or (tok_val is not None and tok[1] != tok_val):
+            raise ValueError(f"Expected {tok_val or tok_type}, got '{tok[1]}'")
+        return tok
+
+
+def _safe_log(x: float) -> float:
+    if x <= 0:
+        raise ValueError("Logarithm is undefined for non-positive numbers")
+    return math.log10(x)
+
+
+def _safe_ln(x: float) -> float:
+    if x <= 0:
+        raise ValueError("Logarithm is undefined for non-positive numbers")
+    return math.log(x)
+
+
+def _safe_sqrt(x: float) -> float:
+    if x < 0:
+        raise ValueError("Cannot take square root of a negative number")
+    return math.sqrt(x)
+
+
+def _safe_factorial(x: float) -> float:
+    if x != int(x) or x < 0:
+        raise ValueError("Factorial is undefined for negative or non-integer values")
+    return float(math.factorial(int(x)))
+
+
+# Supported functions mapping to callables
+_FUNCTIONS: dict[str, object] = {
+    'sin': lambda x: math.sin(math.radians(x)),
+    'cos': lambda x: math.cos(math.radians(x)),
+    'tan': lambda x: math.tan(math.radians(x)),
+    'log': _safe_log,
+    'ln': _safe_ln,
+    'sqrt': _safe_sqrt,
+    'factorial': _safe_factorial,
+    'abs': lambda x: abs(x),
+    'power': lambda x, y: math.pow(x, y),
+}
+
+# Constants
+_CONSTANTS: dict[str, float] = {
+    'pi': math.pi,
+    'e': math.e,
+}
+
+
+class _Parser:
+    """Recursive descent parser for mathematical expressions.
+
+    Grammar:
+        expr       → term (('+' | '-') term)*
+        term       → exponent (('*' | '/') exponent)*
+        exponent   → unary ('^' exponent)?      (right-associative)
+        unary      → '-' unary | primary
+        primary    → NUMBER | CONSTANT | func '(' args ')' | '(' expr ')'
+    """
+
+    def __init__(self, tokenizer: _Tokenizer) -> None:
+        self.tok = tokenizer
+
+    def parse(self) -> float:
+        """Parse the full expression and return result."""
+        result = self._expr()
+        if self.tok.peek() is not None:
+            raise ValueError(f"Unexpected token: '{self.tok.peek()[1]}'")
+        return result
+
+    def _expr(self) -> float:
+        """Parse addition and subtraction (lowest precedence)."""
+        left = self._term()
+        while self.tok.peek() and self.tok.peek()[0] == 'OP' and self.tok.peek()[1] in ('+', '-'):
+            op = self.tok.consume()[1]
+            right = self._term()
+            if op == '+':
+                left = left + right
+            else:
+                left = left - right
+        return left
+
+    def _term(self) -> float:
+        """Parse multiplication and division."""
+        left = self._exponent()
+        while self.tok.peek() and self.tok.peek()[0] == 'OP' and self.tok.peek()[1] in ('*', '/'):
+            op = self.tok.consume()[1]
+            right = self._exponent()
+            if op == '*':
+                left = left * right
+            else:
+                if right == 0:
+                    raise ZeroDivisionError("Cannot divide by zero")
+                left = left / right
+        return left
+
+    def _exponent(self) -> float:
+        """Parse exponentiation (right-associative)."""
+        base = self._unary()
+        if self.tok.peek() and self.tok.peek()[0] == 'OP' and self.tok.peek()[1] == '^':
+            self.tok.consume()
+            exp = self._exponent()  # right-associative via recursion
+            base = math.pow(base, exp)
+        return base
+
+    def _unary(self) -> float:
+        """Parse unary minus."""
+        if self.tok.peek() and self.tok.peek()[0] == 'OP' and self.tok.peek()[1] == '-':
+            self.tok.consume()
+            return -self._unary()
+        return self._primary()
+
+    def _primary(self) -> float:
+        """Parse numbers, constants, function calls, and parenthesized expressions."""
+        tok = self.tok.peek()
+        if tok is None:
+            raise ValueError("Unexpected end of expression")
+
+        # Number literal
+        if tok[0] == 'NUM':
+            self.tok.consume()
+            return float(tok[1])
+
+        # Identifier: constant or function call
+        if tok[0] == 'ID':
+            name = tok[1].lower()
+            self.tok.consume()
+
+            # Check for function call
+            if self.tok.peek() and self.tok.peek()[0] == 'OP' and self.tok.peek()[1] == '(':
+                if name not in _FUNCTIONS:
+                    raise ValueError(f"Unknown function: '{name}'")
+                self.tok.consume()  # consume '('
+                args = [self._expr()]
+                while self.tok.peek() and self.tok.peek()[0] == 'COMMA':
+                    self.tok.consume()
+                    args.append(self._expr())
+                self.tok.expect('OP', ')')
+                try:
+                    return float(_FUNCTIONS[name](*args))
+                except TypeError:
+                    raise ValueError(f"Wrong number of arguments for '{name}'")
+
+            # Constant
+            if name in _CONSTANTS:
+                return _CONSTANTS[name]
+
+            raise ValueError(f"Unknown identifier: '{name}'")
+
+        # Parenthesized expression
+        if tok[0] == 'OP' and tok[1] == '(':
+            self.tok.consume()
+            result = self._expr()
+            self.tok.expect('OP', ')')
+            return result
+
+        raise ValueError(f"Unexpected token: '{tok[1]}'")
+
+
+def evaluate_expression(expr: str) -> float:
+    """Evaluate a mathematical expression string safely.
+
+    Supports arithmetic (+, -, *, /, ^), parentheses, functions
+    (sin, cos, tan, log, ln, sqrt, factorial, abs, power), and
+    constants (pi, e). Trigonometric functions use degrees.
+
+    Args:
+        expr: The expression string to evaluate.
+
+    Returns:
+        The numeric result as a float.
+
+    Raises:
+        ValueError: If the expression is invalid or contains domain errors.
+        ZeroDivisionError: If division by zero occurs.
+    """
+    if not expr or not expr.strip():
+        raise ValueError("Empty expression")
+    tokenizer = _Tokenizer(expr.strip())
+    parser = _Parser(tokenizer)
+    result = parser.parse()
+    if not math.isfinite(result):
+        raise ValueError("Result is not finite")
+    return result
+
+
 if __name__ == "__main__":
     print(f"2 + 3 = {add(2, 3)}")
     print(f"5 - 2 = {subtract(5, 2)}")

--- a/test_main.py
+++ b/test_main.py
@@ -7,6 +7,7 @@ from main import (
     sin_deg, cos_deg, tan_deg,
     sin_rad, cos_rad, tan_rad,
     log10, ln, factorial,
+    evaluate_expression,
 )
 
 
@@ -146,3 +147,155 @@ def test_factorial_invalid():
         factorial(-1)
     with pytest.raises(ValueError):
         factorial(2.5)
+
+
+# ── Expression evaluator ─────────────────────────────────────────────────────
+
+class TestEvaluateExpression:
+    """Tests for the evaluate_expression function."""
+
+    # --- Simple arithmetic ---
+
+    def test_addition(self):
+        assert evaluate_expression("2 + 3") == pytest.approx(5.0)
+
+    def test_subtraction(self):
+        assert evaluate_expression("10 - 4") == pytest.approx(6.0)
+
+    def test_multiplication(self):
+        assert evaluate_expression("3 * 7") == pytest.approx(21.0)
+
+    def test_division(self):
+        assert evaluate_expression("10 / 2") == pytest.approx(5.0)
+
+    def test_exponentiation(self):
+        assert evaluate_expression("2 ^ 10") == pytest.approx(1024.0)
+
+    # --- Operator precedence ---
+
+    def test_precedence_mul_over_add(self):
+        assert evaluate_expression("2 + 3 * 4") == pytest.approx(14.0)
+
+    def test_precedence_div_over_sub(self):
+        assert evaluate_expression("10 - 6 / 3") == pytest.approx(8.0)
+
+    def test_precedence_exp_over_mul(self):
+        assert evaluate_expression("2 * 3 ^ 2") == pytest.approx(18.0)
+
+    # --- Parentheses ---
+
+    def test_parentheses_basic(self):
+        assert evaluate_expression("(2 + 3) * 4") == pytest.approx(20.0)
+
+    def test_nested_parentheses(self):
+        assert evaluate_expression("((2 + 3) * (4 - 1))") == pytest.approx(15.0)
+
+    def test_deeply_nested_parentheses(self):
+        assert evaluate_expression("(((1 + 2)))") == pytest.approx(3.0)
+
+    # --- Unary minus ---
+
+    def test_unary_minus(self):
+        assert evaluate_expression("-5") == pytest.approx(-5.0)
+
+    def test_unary_minus_in_expression(self):
+        assert evaluate_expression("3 + -2") == pytest.approx(1.0)
+
+    def test_unary_minus_with_parens(self):
+        assert evaluate_expression("-(3 + 2)") == pytest.approx(-5.0)
+
+    # --- Functions ---
+
+    def test_sin_zero(self):
+        assert evaluate_expression("sin(0)") == pytest.approx(0.0, abs=1e-9)
+
+    def test_sin_90(self):
+        assert evaluate_expression("sin(90)") == pytest.approx(1.0)
+
+    def test_cos_zero(self):
+        assert evaluate_expression("cos(0)") == pytest.approx(1.0)
+
+    def test_tan_45(self):
+        assert evaluate_expression("tan(45)") == pytest.approx(1.0)
+
+    def test_sqrt_16(self):
+        assert evaluate_expression("sqrt(16)") == pytest.approx(4.0)
+
+    def test_log_100(self):
+        assert evaluate_expression("log(100)") == pytest.approx(2.0)
+
+    def test_ln_e(self):
+        assert evaluate_expression("ln(e)") == pytest.approx(1.0)
+
+    def test_factorial_func(self):
+        assert evaluate_expression("factorial(5)") == pytest.approx(120.0)
+
+    def test_power_func(self):
+        assert evaluate_expression("power(2, 8)") == pytest.approx(256.0)
+
+    # --- Constants ---
+
+    def test_pi_constant(self):
+        assert evaluate_expression("pi") == pytest.approx(math.pi)
+
+    def test_e_constant(self):
+        assert evaluate_expression("e") == pytest.approx(math.e)
+
+    def test_constant_in_expression(self):
+        assert evaluate_expression("2 * pi") == pytest.approx(2 * math.pi)
+
+    # --- Mixed expressions ---
+
+    def test_mixed_sqrt_and_sin(self):
+        assert evaluate_expression("sqrt(16) + sin(0) * 5") == pytest.approx(4.0)
+
+    def test_complex_expression(self):
+        # (2 + 3) * sin(45) - sqrt(16) ≈ 5 * 0.7071 - 4 ≈ -0.4645
+        result = evaluate_expression("(2 + 3) * sin(45) - sqrt(16)")
+        expected = 5 * math.sin(math.radians(45)) - 4
+        assert result == pytest.approx(expected)
+
+    def test_nested_functions(self):
+        assert evaluate_expression("sqrt(abs(-16))") == pytest.approx(4.0)
+
+    # --- Error cases ---
+
+    def test_empty_expression(self):
+        with pytest.raises(ValueError):
+            evaluate_expression("")
+
+    def test_whitespace_only(self):
+        with pytest.raises(ValueError):
+            evaluate_expression("   ")
+
+    def test_invalid_syntax(self):
+        with pytest.raises(ValueError):
+            evaluate_expression("2 +")
+
+    def test_mismatched_parens(self):
+        with pytest.raises(ValueError):
+            evaluate_expression("(2 + 3")
+
+    def test_division_by_zero(self):
+        with pytest.raises(ZeroDivisionError):
+            evaluate_expression("5 / 0")
+
+    def test_sqrt_negative(self):
+        with pytest.raises(ValueError):
+            evaluate_expression("sqrt(-1)")
+
+    def test_log_negative(self):
+        with pytest.raises(ValueError):
+            evaluate_expression("log(-5)")
+
+    def test_unknown_function(self):
+        with pytest.raises(ValueError):
+            evaluate_expression("foo(3)")
+
+    def test_unknown_identifier(self):
+        with pytest.raises(ValueError):
+            evaluate_expression("xyz + 1")
+
+    def test_unexpected_character(self):
+        with pytest.raises(ValueError):
+            evaluate_expression("2 & 3")

--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -1074,4 +1074,131 @@ test.describe("Calculator UI", () => {
       await expect(page.getByTestId("history-result-0")).toHaveText("16");
     });
   });
+
+  // ── Expression Mode ──────────────────────────────────────────────────────
+  test.describe("Expression Mode", () => {
+    test("mode toggle button is visible", async ({ page }) => {
+      await expect(page.getByTestId("btn-mode-toggle")).toBeVisible();
+    });
+
+    test("clicking toggle switches to expression mode", async ({ page }) => {
+      await page.getByTestId("btn-mode-toggle").click();
+      await expect(page.getByTestId("btn-mode-toggle")).toHaveClass(/active/);
+      await expect(page.getByTestId("expr-input")).toBeVisible();
+    });
+
+    test("clicking toggle twice returns to standard mode", async ({ page }) => {
+      await page.getByTestId("btn-mode-toggle").click();
+      await page.getByTestId("btn-mode-toggle").click();
+      await expect(page.getByTestId("btn-mode-toggle")).not.toHaveClass(/active/);
+      await expect(page.getByTestId("expr-input")).not.toBeVisible();
+    });
+
+    test("parentheses buttons visible in expression mode", async ({ page }) => {
+      await page.getByTestId("btn-mode-toggle").click();
+      await expect(page.getByTestId("btn-open-paren")).toBeVisible();
+      await expect(page.getByTestId("btn-close-paren")).toBeVisible();
+    });
+
+    test("parentheses buttons hidden in standard mode", async ({ page }) => {
+      await expect(page.getByTestId("btn-open-paren")).not.toBeVisible();
+      await expect(page.getByTestId("btn-close-paren")).not.toBeVisible();
+    });
+
+    test("typing and evaluating simple expression", async ({ page }) => {
+      await page.getByTestId("btn-mode-toggle").click();
+      const input = page.getByTestId("expr-input");
+      await input.fill("2 + 3");
+      await page.getByTestId("btn-equals").click();
+      await expect(page.getByTestId("value")).toHaveText("5");
+    });
+
+    test("expression with parentheses", async ({ page }) => {
+      await page.getByTestId("btn-mode-toggle").click();
+      const input = page.getByTestId("expr-input");
+      await input.fill("(2 + 3) * 4");
+      await page.getByTestId("btn-equals").click();
+      await expect(page.getByTestId("value")).toHaveText("20");
+    });
+
+    test("expression with function call", async ({ page }) => {
+      await page.getByTestId("btn-mode-toggle").click();
+      const input = page.getByTestId("expr-input");
+      await input.fill("sqrt(16)");
+      await page.getByTestId("btn-equals").click();
+      await expect(page.getByTestId("value")).toHaveText("4");
+    });
+
+    test("expression result added to history", async ({ page }) => {
+      await page.getByTestId("btn-mode-toggle").click();
+      const input = page.getByTestId("expr-input");
+      await input.fill("2 + 3");
+      await page.getByTestId("btn-equals").click();
+      await expect(page.getByTestId("history-item-0")).toBeVisible();
+      await expect(page.getByTestId("history-result-0")).toHaveText("5");
+    });
+
+    test("invalid expression shows error", async ({ page }) => {
+      await page.getByTestId("btn-mode-toggle").click();
+      const input = page.getByTestId("expr-input");
+      await input.fill("2 +");
+      await page.getByTestId("btn-equals").click();
+      await expect(page.getByTestId("value")).toHaveText("Error");
+    });
+
+    test("complex expression evaluates correctly", async ({ page }) => {
+      await page.getByTestId("btn-mode-toggle").click();
+      const input = page.getByTestId("expr-input");
+      await input.fill("2 + 3 * 4");
+      await page.getByTestId("btn-equals").click();
+      await expect(page.getByTestId("value")).toHaveText("14");
+    });
+
+    test("expression with constants", async ({ page }) => {
+      await page.getByTestId("btn-mode-toggle").click();
+      const input = page.getByTestId("expr-input");
+      await input.fill("pi");
+      await page.getByTestId("btn-equals").click();
+      await expect(page.getByTestId("value")).toContainText("3.1415926");
+    });
+
+    test("Enter key evaluates expression", async ({ page }) => {
+      await page.getByTestId("btn-mode-toggle").click();
+      const input = page.getByTestId("expr-input");
+      await input.fill("10 / 2");
+      await input.press("Enter");
+      await expect(page.getByTestId("value")).toHaveText("5");
+    });
+
+    test("mode persists across reload", async ({ page }) => {
+      await page.getByTestId("btn-mode-toggle").click();
+      await expect(page.getByTestId("btn-mode-toggle")).toHaveClass(/active/);
+      await page.reload();
+      await expect(page.getByTestId("btn-mode-toggle")).toHaveClass(/active/);
+      await expect(page.getByTestId("expr-input")).toBeVisible();
+    });
+
+    test("number buttons insert into expression input", async ({ page }) => {
+      await page.getByTestId("btn-mode-toggle").click();
+      await page.getByTestId("btn-5").click();
+      await page.getByTestId("btn-3").click();
+      await expect(page.getByTestId("expr-input")).toHaveValue("53");
+    });
+
+    test("parenthesis buttons insert into expression input", async ({ page }) => {
+      await page.getByTestId("btn-mode-toggle").click();
+      await page.getByTestId("btn-open-paren").click();
+      await page.getByTestId("btn-2").click();
+      await page.getByTestId("btn-close-paren").click();
+      await expect(page.getByTestId("expr-input")).toHaveValue("(2)");
+    });
+
+    test("expression display shows expression after evaluation", async ({ page }) => {
+      await page.getByTestId("btn-mode-toggle").click();
+      const input = page.getByTestId("expr-input");
+      await input.fill("1 + 1");
+      await page.getByTestId("btn-equals").click();
+      await expect(page.getByTestId("expression")).toHaveText("1 + 1 =");
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Implement a safe recursive descent expression parser in `main.py` (`evaluate_expression()`) supporting arithmetic (`+`, `-`, `*`, `/`, `^`), parentheses, functions (`sin`, `cos`, `tan`, `log`, `ln`, `sqrt`, `factorial`, `abs`, `power`), constants (`pi`, `e`), unary minus, and proper operator precedence (PEMDAS) — **no `eval()` or `exec()`**
- Add expression mode to `index.html` with a toggle button, text input field, `(` and `)` buttons, and a matching JS-based recursive descent parser for client-side evaluation
- Mode persists across page reloads via `localStorage`
- Add 39 new unit tests in `test_main.py` covering arithmetic, precedence, parentheses, functions, constants, mixed expressions, and error cases
- Add 17 new Playwright UI tests in `tests/ui.spec.js` for expression mode toggle, evaluation, history integration, keyboard support, and persistence

Closes #20

## Test plan
- [x] All 59 Python unit tests pass (`python -m pytest test_main.py -v`)
- [x] The acceptance criteria expression `(2 + 3) * sin(45) - sqrt(16)` evaluates to ≈ -0.464
- [x] No use of `eval` or `exec` in the parser
- [ ] Playwright tests pass when browser dependencies are available (`npx playwright test`)
- [ ] Mode toggle works and persists across reload
- [ ] Parentheses buttons appear only in expression mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)